### PR TITLE
Better deserialization handling for QTKEnum

### DIFF
--- a/src/qtoolkit/__init__.py
+++ b/src/qtoolkit/__init__.py
@@ -1,1 +1,2 @@
 from qtoolkit._version import __version__
+from qtoolkit.core.data_objects import QJob, QJobInfo, QResources, QState, QSubState

--- a/src/qtoolkit/core/base.py
+++ b/src/qtoolkit/core/base.py
@@ -16,4 +16,17 @@ class QTKObject(supercls):  # type: ignore
 
 
 class QTKEnum(*enum_superclses):  # type: ignore
-    pass
+    @classmethod
+    def _validate_monty(cls, __input_value):
+        """
+        Override the original pydantic Validator for MSONable pattern.
+        If not would not allow to deserialize as a standard Enum in pydantic,
+        that just needs the value.
+        """
+        try:
+            super()._validate_monty(__input_value)
+        except ValueError as e:
+            try:
+                return cls(__input_value)
+            except Exception:
+                raise e


### PR DESCRIPTION
`QTKEnum` had an issue if deserialized inside a pydantic BaseModel. Normally pydantic converts the value to the Enum used to define the field. However, since MSONable have a custom way of dealing with pydantic deserialization, an MSONable Enum was not converted back to an Enum automatically. This should fix it for `QTKEnum`.