### PR TITLE
Correctly handle `float` in `(Slurm|PBS)IO._convert_time_to_str`

### DIFF
--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -156,7 +156,6 @@ $${qverbatim}"""
         )
 
     def _get_job_cmd(self, job_id: str):
-
         cmd = f"qstat -f {job_id}"
 
         return cmd
@@ -170,7 +169,6 @@ $${qverbatim}"""
     def _get_jobs_list_cmd(
         self, job_ids: list[str] | None = None, user: str | None = None
     ) -> str:
-
         if user and job_ids:
             raise ValueError("Cannot query by user and job(s) in PBS")
 
@@ -183,13 +181,11 @@ $${qverbatim}"""
             command.append(f"-u {user}")
 
         if job_ids:
-
             command.append(" ".join(job_ids))
 
         return " ".join(command)
 
     def parse_jobs_list_output(self, exit_code, stdout, stderr) -> list[QJob]:
-
         if isinstance(stdout, bytes):
             stdout = stdout.decode()
         if isinstance(stderr, bytes):
@@ -358,7 +354,7 @@ $${qverbatim}"""
 
     @staticmethod
     def _convert_time_to_str(time: int | timedelta) -> str:
-        if isinstance(time, int):
+        if not isinstance(time, timedelta):
             time = timedelta(seconds=time)
 
         hours, remainder = divmod(int(time.total_seconds()), 3600)

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -353,7 +353,7 @@ $${qverbatim}"""
     }
 
     @staticmethod
-    def _convert_time_to_str(time: int | timedelta) -> str:
+    def _convert_time_to_str(time: int | float | timedelta) -> str:
         if not isinstance(time, timedelta):
             time = timedelta(seconds=time)
 

--- a/src/qtoolkit/io/slurm.py
+++ b/src/qtoolkit/io/slurm.py
@@ -540,7 +540,7 @@ $${qverbatim}"""
 
     @staticmethod
     def _convert_time_to_str(time: int | timedelta) -> str:
-        if isinstance(time, int):
+        if not isinstance(time, timedelta):
             time = timedelta(seconds=time)
 
         days = time.days

--- a/src/qtoolkit/io/slurm.py
+++ b/src/qtoolkit/io/slurm.py
@@ -539,7 +539,7 @@ $${qverbatim}"""
         return v * (1024 ** power_labels[units])
 
     @staticmethod
-    def _convert_time_to_str(time: int | timedelta) -> str:
+    def _convert_time_to_str(time: int | float | timedelta) -> str:
         if not isinstance(time, timedelta):
             time = timedelta(seconds=time)
 

--- a/tests/io/test_slurm.py
+++ b/tests/io/test_slurm.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from monty.serialization import loadfn
+
 from qtoolkit.core.data_objects import ProcessPlacement, QResources, QState
 from qtoolkit.core.exceptions import OutputParsingError, UnsupportedResourcesError
 from qtoolkit.io.slurm import SlurmIO, SlurmState

--- a/tests/io/test_slurm.py
+++ b/tests/io/test_slurm.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 from monty.serialization import loadfn
-
 from qtoolkit.core.data_objects import ProcessPlacement, QResources, QState
 from qtoolkit.core.exceptions import OutputParsingError, UnsupportedResourcesError
 from qtoolkit.io.slurm import SlurmIO, SlurmState
@@ -190,6 +189,14 @@ class TestSlurmIO:
             timedelta(days=15, hours=21, minutes=19, seconds=32)
         )
         assert time_str == "15-21:19:32"
+
+        # test float
+        time_str = slurm_io._convert_time_to_str(602.0)
+        assert time_str == "0-0:10:2"
+
+        # test negative
+        time_str = slurm_io._convert_time_to_str(-10)
+        assert time_str == "-1-23:59:50"
 
     def test_check_convert_qresources(self, slurm_io):
         res = QResources(

--- a/tests/io/test_slurm.py
+++ b/tests/io/test_slurm.py
@@ -196,6 +196,8 @@ class TestSlurmIO:
         assert time_str == "0-0:10:2"
 
         # test negative
+        # negative time makes no sense and should not be passed. this test is just to be alerted
+        # if the output for negative numbers changes
         time_str = slurm_io._convert_time_to_str(-10)
         assert time_str == "-1-23:59:50"
 


### PR DESCRIPTION
to set the time limit to half a day, i was using

```py
resources = QResources(
    # ...
    time_limit=60 * 60 * 24 * 0.5,  # in seconds
)
```

and encountered

```py
│     remote = {                                                                                                  │
│                  'step_attempts': 2,                                                                            │
│                  'retry_time_limit': '2024-07-24 19:13',                                                        │
│                  'error': Traceback (most recent call last):                                                    │
│                File                                                                                             │
│              "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/jobs/jobcontroller.py",   │
│              line 3340, in lock_job_for_update                                                                  │
│                  yield lock                                                                                     │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/jobs/runner.py",   │
│              line 539, in advance_state                                                                         │
│                  states_methods[state](lock)                                                                    │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/jobs/runner.py",   │
│              line 686, in submit                                                                                │
│                  submit_result = queue_manager.submit(                                                          │
│                                  ^^^^^^^^^^^^^^^^^^^^^                                                          │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/remote/queue.py",  │
│              line 153, in submit                                                                                │
│                  script_fpath = self.write_submission_script(                                                   │
│                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                   │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/remote/queue.py",  │
│              line 184, in write_submission_script                                                               │
│                  script_str = self.get_submission_script(                                                       │
│                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                       │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/jobflow_remote/remote/queue.py",  │
│              line 99, in get_submission_script                                                                  │
│                  return self.scheduler_io.get_submission_script(commands_list, options)                         │
│                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/qtoolkit/io/base.py", line 57, in │
│              get_submission_script                                                                              │
│                  if header := self.generate_header(options):                                                    │
│                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                     │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/qtoolkit/io/base.py", line 79, in │
│              generate_header                                                                                    │
│                  options = self.check_convert_qresources(options)                                               │
│                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                               │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/qtoolkit/io/base.py", line 186,   │
│              in check_convert_qresources                                                                        │
│                  return self._convert_qresources(resources)                                                     │
│                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                     │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/qtoolkit/io/slurm.py", line 582,  │
│              in _convert_qresources                                                                             │
│                  header_dict["time"] = self._convert_time_to_str(resources.time_limit)                          │
│                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          │
│                File "/scratch/janosh/.venv/py312/lib/python3.12/site-packages/qtoolkit/io/slurm.py", line 546,  │
│              in _convert_time_to_str                                                                            │
│                  days = time.days                                                                               │
│                         ^^^^^^^^^                                                                               │
│              AttributeError: 'float' object has no attribute 'days'                                             │
│                                                                                                                 │
│              }                                                                                                  │
│    run_dir = '/scratch/janosh/jobs/35/ff/e2/35ffe263-f048-45e9-8479-a8f97fa69435_1'  
```

this PR changes

```diff
- if isinstance(time, int):
+ if not isinstance(time, timedelta):
    time = timedelta(seconds=time)
```

another option worth considering would be `if isinstance(time, float):`