### PR TITLE
Fix `mem_per_cpu` in `SlurmIO` not being passed as snake_case

### DIFF
--- a/src/qtoolkit/io/slurm.py
+++ b/src/qtoolkit/io/slurm.py
@@ -555,7 +555,7 @@ $${qverbatim}"""
     _qresources_mapping = {
         "queue_name": "partition",
         "job_name": "job_name",
-        "memory_per_thread": "mem-per-cpu",
+        "memory_per_thread": "mem_per_cpu",
         "account": "account",
         "qos": "qos",
         "priority": "priority",

--- a/tests/io/test_slurm.py
+++ b/tests/io/test_slurm.py
@@ -224,7 +224,7 @@ class TestSlurmIO:
         assert header_dict == {
             "partition": "myqueue",
             "job_name": "myjob",
-            "mem-per-cpu": 2048,
+            "mem_per_cpu": 2048,
             "account": "myaccount",
             "qos": "myqos",
             "qout_path": "someoutputpath",


### PR DESCRIPTION
passing `memory_per_thread` currently crashes job submissions with `ValueError`

```py
resources = QResources(
   # ...
   memory_per_thread=10_000,
)
```

reason being that it's mapped to `mem-per-gpu` by `_qresources_mapping`

https://github.com/Matgenix/qtoolkit/blob/346c0d6fecf109f207df34175e1fa9e4d7ef8902/src/qtoolkit/io/slurm.py#L558

but

https://github.com/Matgenix/qtoolkit/blob/346c0d6fecf109f207df34175e1fa9e4d7ef8902/src/qtoolkit/io/slurm.py#L157

expects it as snake case

```py
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/jo… 
line 3334, in lock_job_for_update                                            
    yield lock                                                               
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/jo… 
line 538, in advance_state                                                   
    states_methods[state](lock)                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/jo… 
line 685, in submit                                                          
    submit_result = queue_manager.submit(                                    
                    ^^^^^^^^^^^^^^^^^^^^^                                    
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/re… 
line 155, in submit                                                          
    script_fpath = self.write_submission_script(                             
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                             
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/re… 
line 186, in write_submission_script                                         
    script_str = self.get_submission_script(                                 
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                 
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/jobflow_remote/re… 
line 104, in get_submission_script                                           
    return self.scheduler_io.get_submission_script(commands_list, options)   
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/qtoolkit/io/base.… 
line 57, in get_submission_script                                            
    if header := self.generate_header(options):                              
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                               
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/qtoolkit/io/base.… 
line 88, in generate_header                                                  
    raise ValueError(msg)                                                    
ValueError: The following keys are not present in the template: mem-per-cpu  
                                                                             
}
```