### PR TITLE
Fix codecov upload in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,11 @@ jobs:
         run: pytest --cov=qtoolkit --cov-report=xml
 
       - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: matgenix/qtoolkit
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For some reason the codecov token hasn't been properly used for the last few months, and codecov uploads have been silently failing.