### PR TITLE
improve message for missing keys

### DIFF
--- a/src/qtoolkit/io/base.py
+++ b/src/qtoolkit/io/base.py
@@ -93,12 +93,12 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
                     close_matches[extra_val] = m[0]
             msg = (
                 f"The following keys are not present in the template: {', '.join(sorted(extra))}. "
-                f"Check the template in {type(self).__module__}.{type(self).__qualname__}.header_template"
+                f"Check the template in {type(self).__module__}.{type(self).__qualname__}.header_template."
             )
             if close_matches:
-                msg += "Possible replacements:"
-                for extra_val, match in close_matches.items():
-                    msg += f" {match} instead of {extra_val}."
+                msg += " Possible replacements:"
+                for extra_val in sorted(close_matches):
+                    msg += f" {close_matches[extra_val]} instead of {extra_val}."
             raise ValueError(msg)
 
         unclean_header = template.safe_substitute(options)

--- a/src/qtoolkit/io/base.py
+++ b/src/qtoolkit/io/base.py
@@ -88,9 +88,11 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
         if extra:
             close_matches = {}
             for extra_val in extra:
-                m = difflib.get_close_matches(extra_val, all_identifiers, n=1)
+                m = difflib.get_close_matches(
+                    extra_val, all_identifiers, n=3, cutoff=0.65
+                )
                 if m:
-                    close_matches[extra_val] = m[0]
+                    close_matches[extra_val] = m
             msg = (
                 f"The following keys are not present in the template: {', '.join(sorted(extra))}. "
                 f"Check the template in {type(self).__module__}.{type(self).__qualname__}.header_template."
@@ -98,7 +100,10 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
             if close_matches:
                 msg += " Possible replacements:"
                 for extra_val in sorted(close_matches):
-                    msg += f" {close_matches[extra_val]} instead of {extra_val}."
+                    replacements = " or ".join(
+                        f"'{m}'" for m in close_matches[extra_val]
+                    )
+                    msg += f" {replacements} instead of '{extra_val}'."
             raise ValueError(msg)
 
         unclean_header = template.safe_substitute(options)

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -144,9 +144,12 @@ class TestBaseScheduler:
 #SPECCMD --nodes=4"""
         )
 
+        # check that the error message contains the expected error, but should not match
+        # the possible replacements, as they are too different
         with pytest.raises(
             ValueError,
-            match=r"The following keys are not present in the template: tata, titi. Check the template in .*MyScheduler.header_template",
+            match=r"The following keys are not present in the template: tata, titi. Check "
+            r"the template in .*MyScheduler.header_template(?!.*instead of 'titi')",
         ):
             res = QResources(
                 nodes=4,
@@ -158,7 +161,8 @@ class TestBaseScheduler:
         with pytest.raises(
             ValueError,
             match=r"The following keys are not present in the template: option32, processes-per-node. "
-            r"Check the template in .*MyScheduler.header_template.*option3 instead of option32. processes_per_node instead of processes-per-node",
+            r"Check the template in .*MyScheduler.header_template.*'option3' or 'option2' or 'option1' "
+            r"instead of 'option32'. 'processes_per_node' or 'processes' instead of 'processes-per-node'",
         ):
             res = QResources(
                 nodes=4,

--- a/tests/io/test_base.py
+++ b/tests/io/test_base.py
@@ -146,12 +146,24 @@ class TestBaseScheduler:
 
         with pytest.raises(
             ValueError,
-            match=r"The following keys are not present in the template: tata, titi",
+            match=r"The following keys are not present in the template: tata, titi. Check the template in .*MyScheduler.header_template",
         ):
             res = QResources(
                 nodes=4,
                 processes_per_node=16,
                 scheduler_kwargs={"tata": "tata", "titi": "titi"},
+            )
+            scheduler.generate_header(res)
+
+        with pytest.raises(
+            ValueError,
+            match=r"The following keys are not present in the template: option32, processes-per-node. "
+            r"Check the template in .*MyScheduler.header_template.*option3 instead of option32. processes_per_node instead of processes-per-node",
+        ):
+            res = QResources(
+                nodes=4,
+                processes_per_node=16,
+                scheduler_kwargs={"option32": "xxx", "processes-per-node": "yyy"},
             )
             scheduler.generate_header(res)
 


### PR DESCRIPTION
Closes #48.
Provide a clearer error message, suggesting a possible alternative for the wrong template field and pointing to the actual location of the template.