### PR TITLE
Sanitization of job name and tests for PBS

### DIFF
--- a/src/qtoolkit/core/data_objects.py
+++ b/src/qtoolkit/core/data_objects.py
@@ -202,12 +202,14 @@ class QResources(QTKObject):
                 raise UnsupportedResourcesError(msg)
         self.scheduler_kwargs = self.scheduler_kwargs or {}
 
-    def _check_no_values(self) -> bool:
+    def _check_no_values(
+        self, excluded=("job_name", "output_filepath", "error_filepath")
+    ) -> bool:
         """
         Check if all the attributes are None or empty.
         """
         for f in fields(self):
-            if self.__getattribute__(f.name):
+            if excluded and f.name not in excluded and self.__getattribute__(f.name):
                 return False
 
         return True

--- a/src/qtoolkit/core/data_objects.py
+++ b/src/qtoolkit/core/data_objects.py
@@ -206,23 +206,13 @@ class QResources(QTKObject):
         self, excluded=("job_name", "output_filepath", "error_filepath")
     ) -> bool:
         """
-        Check if all the attributes are None or empty.
+        Check if all the attributes are None or empty, except the excluded ones.
         """
+        excluded = excluded or []
         for f in fields(self):
-            if excluded and f.name not in excluded and self.__getattribute__(f.name):
+            if f.name not in excluded and self.__getattribute__(f.name):
                 return False
 
-        return True
-
-    def check_empty(self) -> bool:
-        """
-        Check if the QResouces is empty and its content is coherent.
-        Raises an error if process_placement is None, but some attributes are set.
-        """
-        if self.process_placement is not None:
-            return False
-        if not self._check_no_values():
-            raise ValueError("process_placement is None, but some values are set")
         return True
 
     @classmethod

--- a/src/qtoolkit/host/remote.py
+++ b/src/qtoolkit/host/remote.py
@@ -135,7 +135,9 @@ class RemoteHost(BaseHost):
         self.config = config
         self._connection = fabric.Connection(
             host=self.config.host,
+            port=self.config.port,
             user=self.config.user,
+            connect_kwargs=self.config.connect_kwargs,
         )
 
     @property

--- a/src/qtoolkit/io/base.py
+++ b/src/qtoolkit/io/base.py
@@ -48,6 +48,8 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
 
     shebang: str = "#!/bin/bash"
 
+    sanitize_job_name: bool = False
+
     def get_submission_script(
         self,
         commands: str | list[str],
@@ -106,6 +108,7 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
                     msg += f" {replacements} instead of '{extra_val}'."
             raise ValueError(msg)
 
+        options = self.sanitize_options(options)
         unclean_header = template.safe_substitute(options)
         # Remove lines with leftover $$.
         clean_header = []
@@ -241,3 +244,10 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
     @abc.abstractmethod
     def parse_jobs_list_output(self, exit_code, stdout, stderr) -> list[QJob]:
         pass
+
+    def sanitize_options(self, options):
+        """
+        A function to sanitize the values in the options used to generate the
+        header. Subclasses should implement their own sanitizations.
+        """
+        return options

--- a/src/qtoolkit/io/base.py
+++ b/src/qtoolkit/io/base.py
@@ -78,8 +78,7 @@ class BaseSchedulerIO(QTKObject, abc.ABC):
         options = options or {}
 
         if isinstance(options, QResources):
-            if not options.check_empty():
-                options = self.check_convert_qresources(options)
+            options = self.check_convert_qresources(options)
 
         template = QTemplate(self.header_template)
 

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -120,7 +120,7 @@ $${qverbatim}"""
             command.append(f"-u {user}")
 
         if job_ids:
-            job_ids_str = ",".join(job_ids)
+            job_ids_str = " ".join(job_ids)
             command.append(self._get_job_ids_flag(job_ids_str))
 
         return " ".join(command)

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -135,7 +135,7 @@ $${qverbatim}"""
         return ["qstat", "-f", "-w"]
 
     def _get_job_cmd(self, job_id: str):
-        cmd = f"qstat -f -w {job_id}"
+        cmd = f"{' '.join(self._get_qstat_base_command())} {job_id}"
         return cmd
 
     def _get_job_ids_flag(self, job_ids_str: str) -> str:

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -135,15 +135,11 @@ $${qverbatim}"""
         return ["qstat", "-f", "-w"]
 
     def _get_job_cmd(self, job_id: str):
-        cmd = f"qstat -f {job_id}"
+        cmd = f"qstat -f -w {job_id}"
         return cmd
 
     def _get_job_ids_flag(self, job_ids_str: str) -> str:
         return job_ids_str
-
-    def _get_job_cmd(self, job_id: str):
-        cmd = f"qstat -f {job_id}"
-        return cmd
 
     def parse_jobs_list_output(self, exit_code, stdout, stderr) -> list[QJob]:
         if isinstance(stdout, bytes):

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -132,7 +132,7 @@ $${qverbatim}"""
         return None
 
     def _get_qstat_base_command(self) -> list[str]:
-        return ["qstat", "-f"]
+        return ["qstat", "-f", "-w"]
 
     def _get_job_cmd(self, job_id: str):
         cmd = f"qstat -f {job_id}"

--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -134,6 +134,10 @@ $${qverbatim}"""
     def _get_qstat_base_command(self) -> list[str]:
         return ["qstat", "-f"]
 
+    def _get_job_cmd(self, job_id: str):
+        cmd = f"qstat -f {job_id}"
+        return cmd
+
     def _get_job_ids_flag(self, job_ids_str: str) -> str:
         return job_ids_str
 
@@ -272,3 +276,9 @@ $${qverbatim}"""
             raise OutputParsingError()
 
         return time[3] * 86400 + time[2] * 3600 + time[1] * 60 + time[0]
+
+    def sanitize_options(self, options):
+        if "job_name" in options:
+            options = dict(options)
+            options["job_name"] = re.sub(r"[^a-zA-Z0-9_\-+.]", "_", options["job_name"])
+        return options

--- a/src/qtoolkit/io/pbs_base.py
+++ b/src/qtoolkit/io/pbs_base.py
@@ -215,7 +215,6 @@ class PBSIOBase(BaseSchedulerIO, ABC):
 
         return header_dict
 
-    @abc.abstractmethod
     def _add_soft_walltime(self, header_dict: dict, resources: QResources):
         """Add soft_walltime if required by child classes (SGE)."""
 

--- a/src/qtoolkit/io/pbs_base.py
+++ b/src/qtoolkit/io/pbs_base.py
@@ -216,7 +216,7 @@ class PBSIOBase(BaseSchedulerIO, ABC):
         return header_dict
 
     def _add_soft_walltime(self, header_dict: dict, resources: QResources):
-        """Add soft_walltime if required by child classes (SGE)."""
+        """Add soft_walltime if required by child classes (e.g., SGE)."""
 
     @property
     def supported_qresources_keys(self) -> list:

--- a/src/qtoolkit/io/sge.py
+++ b/src/qtoolkit/io/sge.py
@@ -385,3 +385,9 @@ $${qverbatim}"""
         header_dict["soft_walltime"] = self._convert_time_to_str(
             resources.time_limit * 0.99
         )
+
+    def sanitize_options(self, options):
+        if "job_name" in options:
+            options = dict(options)
+            options["job_name"] = re.sub(r"[\s/@*\\:]", "_", options["job_name"])
+        return options

--- a/src/qtoolkit/io/shell.py
+++ b/src/qtoolkit/io/shell.py
@@ -259,7 +259,6 @@ $${qverbatim}
         """
         Converts a QResources instance to a dict that will be used to fill in the
         header of the submission script.
-        Only an empty QResources is accepted in ShellIO.
         """
         header_dict = {}
         for qr_field, slurm_field in self._qresources_mapping.items():

--- a/tests/core/test_data_objects.py
+++ b/tests/core/test_data_objects.py
@@ -551,20 +551,6 @@ class TestQResources:
         proc_distr = qr.get_processes_distribution()
         assert proc_distr == [None, None, None]
 
-    def test_is_empty(self):
-        qr = QResources()
-        assert qr.check_empty()
-
-        qr = QResources(process_placement=ProcessPlacement.NO_CONSTRAINTS, processes=10)
-        assert not qr.check_empty()
-
-        qr = QResources(process_placement=None)
-        qr.processes = 10
-        with pytest.raises(
-            ValueError, match="process_placement is None, but some values are set"
-        ):
-            qr.check_empty()
-
 
 class TestQJobInfo:
     def test_equality(self):

--- a/tests/io/test_pbs.py
+++ b/tests/io/test_pbs.py
@@ -136,11 +136,11 @@ class TestPBSIO:
         ):
             pbs_io._get_jobs_list_cmd(job_ids=["1"], user="johndoe")
         cmd = pbs_io._get_jobs_list_cmd(user="johndoe")
-        assert cmd == "qstat -f -u johndoe"
+        assert cmd == "qstat -f -w -u johndoe"
         cmd = pbs_io._get_jobs_list_cmd(job_ids=["1", "3", "56", "15"])
-        assert cmd == "qstat -f 1,3,56,15"
+        assert cmd == "qstat -f -w 1 3 56 15"
         cmd = pbs_io._get_jobs_list_cmd(job_ids=["1"])
-        assert cmd == "qstat -f 1"
+        assert cmd == "qstat -f -w 1"
 
     def test_convert_str_to_time(self, pbs_io):
         time_seconds = pbs_io._convert_str_to_time("10:51:13")

--- a/tests/io/test_pbs.py
+++ b/tests/io/test_pbs.py
@@ -126,9 +126,9 @@ class TestPBSIO:
 
     def test_get_job_cmd(self, pbs_io):
         cmd = pbs_io._get_job_cmd(3)
-        assert cmd == "qstat -f 3"
+        assert cmd == "qstat -f -w 3"
         cmd = pbs_io._get_job_cmd("56")
-        assert cmd == "qstat -f 56"
+        assert cmd == "qstat -f -w 56"
 
     def test_get_jobs_list_cmd(self, pbs_io):
         with pytest.raises(

--- a/tests/io/test_shell.py
+++ b/tests/io/test_shell.py
@@ -211,17 +211,6 @@ class TestShellIO:
         qr = QResources()
         assert shell_io.check_convert_qresources(qr) == {}
 
-    def test_convert_qresources(self, shell_io):
-        qr = QResources(processes=1)
-        with pytest.raises(
-            UnsupportedResourcesError,
-            match=r"Only empty QResources is supported",
-        ):
-            shell_io._convert_qresources(qr)
-
-        qr = QResources()
-        assert shell_io._convert_qresources(qr) == {}
-
     def test_header(self, shell_io):
         # check that the required elements are properly handled in header template
         options = {

--- a/tests/io/test_shell.py
+++ b/tests/io/test_shell.py
@@ -211,6 +211,15 @@ class TestShellIO:
         qr = QResources()
         assert shell_io.check_convert_qresources(qr) == {}
 
+        qr = QResources(
+            job_name="test", output_filepath="t.out", error_filepath="t.err"
+        )
+        assert shell_io.check_convert_qresources(qr) == {
+            "job_name": "test",
+            "qerr_path": "t.err",
+            "qout_path": "t.out",
+        }
+
     def test_header(self, shell_io):
         # check that the required elements are properly handled in header template
         options = {

--- a/tests/test_data/io/pbs/create_parse_cancel_output_inout.py
+++ b/tests/test_data/io/pbs/create_parse_cancel_output_inout.py
@@ -1,0 +1,105 @@
+import json
+
+import yaml
+
+from qtoolkit.io.pbs import PBSIO
+
+pbs_io = PBSIO()
+
+mylist = []
+
+# First case: successful termination
+return_code = 0
+stdout = b""
+stderr = b""
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+# Second case: no job identification provided
+return_code = 1
+stdout = b""
+stderr = b"""usage:
+    qdel [-W force|suppress_email=X] [-x] job_identifier...
+    qdel --version
+"""
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+# Third case: access/permission denied
+return_code = 210
+stdout = b""
+stderr = b"qdel: Unauthorized Request  210\n"
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+# Fourth case: invalid job id
+return_code = 1
+stdout = b""
+stderr = b"qdel: illegally formed job identifier: a\n"
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+# Fifth case: job already completed
+return_code = 1
+stdout = b""
+stderr = b"qdel: Job has finished 8\n"
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+# Sixth case: unkwnown job id
+return_code = 1
+stdout = b""
+stderr = b"qdel: Unknown Job Id 120\n"
+
+cr = pbs_io.parse_cancel_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+
+a = {
+    "parse_cancel_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "cancel_result_ref": json.dumps(cr.as_dict()),
+}
+mylist.append(a)
+
+with open("parse_cancel_output_inout.yaml", "w") as f:
+    yaml.dump(mylist, f, sort_keys=False)

--- a/tests/test_data/io/pbs/create_parse_job_output_inout.py
+++ b/tests/test_data/io/pbs/create_parse_job_output_inout.py
@@ -1,0 +1,88 @@
+import json
+
+import yaml
+
+from qtoolkit.io.pbs import PBSIO
+
+pbs_io = PBSIO()
+
+mylist = []
+
+# First case: successful job parsing
+return_code = 0
+stdout = b"""Job Id: 14
+    Job_Name = myscript_1
+    Job_Owner = testu@f41a0fbae027
+    resources_used.cpupercent = 0
+    resources_used.cput = 00:00:00
+    resources_used.mem = 0kb
+    resources_used.ncpus = 1
+    resources_used.vmem = 0kb
+    resources_used.walltime = 00:00:00
+    job_state = R
+    queue = workq
+    server = f41a0fbae027
+    Checkpoint = u
+    ctime = Sun Dec 29 20:13:12 2024
+    Error_Path = f41a0fbae027:/home/testu/myscript_1.e14
+    exec_host = f41a0fbae027/0
+    exec_vnode = (f41a0fbae027:ncpus=1)
+    Hold_Types = n
+    Join_Path = n
+    Keep_Files = n
+    Mail_Points = a
+    mtime = Sun Dec 29 20:13:14 2024
+    Output_Path = f41a0fbae027:/home/testu/myscript_1.o14
+    Priority = 0
+    qtime = Sun Dec 29 20:13:12 2024
+    Rerunable = True
+    Resource_List.ncpus = 1
+    Resource_List.nodect = 1
+    Resource_List.nodes = 1:ppn=1
+    Resource_List.place = scatter
+    Resource_List.select = 1:ncpus=1
+    Resource_List.walltime = 01:00:00
+    stime = Sun Dec 29 20:13:12 2024
+    session_id = 1534
+    Shell_Path_List = /bin/bash
+    jobdir = /home/testu
+    substate = 42
+    Variable_List = PBS_O_HOME=/home/testu,PBS_O_LANG=C.UTF-8,
+    PBS_O_LOGNAME=testu,
+    PBS_O_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bi
+    n:/usr/games:/usr/local/games:/snap/bin:/opt/pbs/bin,
+    PBS_O_SHELL=/bin/bash,PBS_O_WORKDIR=/home/testu,PBS_O_SYSTEM=Linux,
+    PBS_O_QUEUE=workq,PBS_O_HOST=f41a0fbae027
+    comment = Job run at Sun Dec 29 at 20:13 on (f41a0fbae027:ncpus=1)
+    etime = Sun Dec 29 20:13:12 2024
+    run_count = 1
+    Submit_arguments = test_submit.sh
+    project = _pbs_project_default
+    Submit_Host = f41a0fbae027
+"""
+stderr = b""
+job = pbs_io.parse_job_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+a = {
+    "parse_job_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "job_ref": json.dumps(job.as_dict()),
+}
+mylist.append(a)
+
+
+# Second case: empty stdout and stderr
+return_code = 0
+stdout = b""
+stderr = b""
+job = pbs_io.parse_job_output(exit_code=return_code, stdout=stdout, stderr=stderr)
+a = {
+    "parse_job_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "job_ref": json.dumps(job.as_dict() if job is not None else None),
+}
+mylist.append(a)
+
+with open("parse_job_output_inout.yaml", "w") as f:
+    yaml.dump(mylist, f, sort_keys=False)

--- a/tests/test_data/io/pbs/create_parse_submit_output_inout.py
+++ b/tests/test_data/io/pbs/create_parse_submit_output_inout.py
@@ -1,0 +1,45 @@
+import json
+
+import yaml
+
+from qtoolkit.io.pbs import PBSIO
+
+pbs_io = PBSIO()
+
+mylist = []
+
+# First case: invalid queue specified
+return_code = 1
+stdout = b""
+stderr = b"qsub: Unknown queue\n"
+
+sr = pbs_io.parse_submit_output(
+    exit_code=return_code, stdout=stdout.decode(), stderr=stderr.decode()
+)
+
+a = {
+    "parse_submit_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "submission_result_ref": json.dumps(sr.as_dict()),
+}
+mylist.append(a)
+
+# Second case: successful submission
+return_code = 0
+stdout = b"24\n"
+stderr = b""
+sr = pbs_io.parse_submit_output(
+    exit_code=return_code, stdout=stdout.decode(), stderr=stderr.decode()
+)
+a = {
+    "parse_submit_kwargs": json.dumps(
+        {"exit_code": return_code, "stdout": stdout.decode(), "stderr": stderr.decode()}
+    ),
+    "submission_result_ref": json.dumps(sr.as_dict()),
+}
+mylist.append(a)
+
+
+with open("parse_submit_output_inout.yaml", "w") as f:
+    yaml.dump(mylist, f, sort_keys=False)

--- a/tests/test_data/io/pbs/parse_cancel_output_inout.yaml
+++ b/tests/test_data/io/pbs/parse_cancel_output_inout.yaml
@@ -1,0 +1,42 @@
+- parse_cancel_kwargs: '{"exit_code": 0, "stdout": "", "stderr": ""}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 0, "stdout": "", "stderr": "", "status": {"@module": "qtoolkit.core.data_objects",
+    "@class": "CancelStatus", "@version": "0.1.5.post38+g62b683f.d20241229", "value":
+    "SUCCESSFUL"}}'
+- parse_cancel_kwargs: '{"exit_code": 1, "stdout": "", "stderr": "usage:\n    qdel
+    [-W force|suppress_email=X] [-x] job_identifier...\n    qdel --version\n"}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 1, "stdout": "", "stderr": "usage:\n    qdel [-W force|suppress_email=X]
+    [-x] job_identifier...\n    qdel --version\n", "status": {"@module": "qtoolkit.core.data_objects",
+    "@class": "CancelStatus", "@version": "0.1.5.post38+g62b683f.d20241229", "value":
+    "FAILED"}}'
+- parse_cancel_kwargs: '{"exit_code": 210, "stdout": "", "stderr": "qdel: Unauthorized
+    Request  210\n"}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 210, "stdout": "", "stderr": "qdel: Unauthorized Request  210\n",
+    "status": {"@module": "qtoolkit.core.data_objects", "@class": "CancelStatus",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "value": "FAILED"}}'
+- parse_cancel_kwargs: '{"exit_code": 1, "stdout": "", "stderr": "qdel: illegally
+    formed job identifier: a\n"}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 1, "stdout": "", "stderr": "qdel: illegally formed job identifier:
+    a\n", "status": {"@module": "qtoolkit.core.data_objects", "@class": "CancelStatus",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "value": "FAILED"}}'
+- parse_cancel_kwargs: '{"exit_code": 1, "stdout": "", "stderr": "qdel: Job has finished
+    8\n"}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 1, "stdout": "", "stderr": "qdel: Job has finished 8\n", "status":
+    {"@module": "qtoolkit.core.data_objects", "@class": "CancelStatus", "@version":
+    "0.1.5.post38+g62b683f.d20241229", "value": "FAILED"}}'
+- parse_cancel_kwargs: '{"exit_code": 1, "stdout": "", "stderr": "qdel: Unknown Job
+    Id 120\n"}'
+  cancel_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "CancelResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 1, "stdout": "", "stderr": "qdel: Unknown Job Id 120\n", "status":
+    {"@module": "qtoolkit.core.data_objects", "@class": "CancelStatus", "@version":
+    "0.1.5.post38+g62b683f.d20241229", "value": "FAILED"}}'

--- a/tests/test_data/io/pbs/parse_job_output_inout.yaml
+++ b/tests/test_data/io/pbs/parse_job_output_inout.yaml
@@ -1,0 +1,29 @@
+- parse_job_kwargs: '{"exit_code": 0, "stdout": "Job Id: 14\n    Job_Name = myscript_1\n    Job_Owner
+    = testu@f41a0fbae027\n    resources_used.cpupercent = 0\n    resources_used.cput
+    = 00:00:00\n    resources_used.mem = 0kb\n    resources_used.ncpus = 1\n    resources_used.vmem
+    = 0kb\n    resources_used.walltime = 00:00:00\n    job_state = R\n    queue =
+    workq\n    server = f41a0fbae027\n    Checkpoint = u\n    ctime = Sun Dec 29 20:13:12
+    2024\n    Error_Path = f41a0fbae027:/home/testu/myscript_1.e14\n    exec_host
+    = f41a0fbae027/0\n    exec_vnode = (f41a0fbae027:ncpus=1)\n    Hold_Types = n\n    Join_Path
+    = n\n    Keep_Files = n\n    Mail_Points = a\n    mtime = Sun Dec 29 20:13:14
+    2024\n    Output_Path = f41a0fbae027:/home/testu/myscript_1.o14\n    Priority
+    = 0\n    qtime = Sun Dec 29 20:13:12 2024\n    Rerunable = True\n    Resource_List.ncpus
+    = 1\n    Resource_List.nodect = 1\n    Resource_List.nodes = 1:ppn=1\n    Resource_List.place
+    = scatter\n    Resource_List.select = 1:ncpus=1\n    Resource_List.walltime =
+    01:00:00\n    stime = Sun Dec 29 20:13:12 2024\n    session_id = 1534\n    Shell_Path_List
+    = /bin/bash\n    jobdir = /home/testu\n    substate = 42\n    Variable_List =
+    PBS_O_HOME=/home/testu,PBS_O_LANG=C.UTF-8,\n    PBS_O_LOGNAME=testu,\n    PBS_O_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bi\n    n:/usr/games:/usr/local/games:/snap/bin:/opt/pbs/bin,\n    PBS_O_SHELL=/bin/bash,PBS_O_WORKDIR=/home/testu,PBS_O_SYSTEM=Linux,\n    PBS_O_QUEUE=workq,PBS_O_HOST=f41a0fbae027\n    comment
+    = Job run at Sun Dec 29 at 20:13 on (f41a0fbae027:ncpus=1)\n    etime = Sun Dec
+    29 20:13:12 2024\n    run_count = 1\n    Submit_arguments = test_submit.sh\n    project
+    = _pbs_project_default\n    Submit_Host = f41a0fbae027\n", "stderr": ""}'
+  job_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "QJob", "@version":
+    "0.1.5.post38+g62b683f.d20241229", "name": "myscript_1", "job_id": "14", "exit_status":
+    null, "state": {"@module": "qtoolkit.core.data_objects", "@class": "QState", "@version":
+    "0.1.5.post38+g62b683f.d20241229", "value": "RUNNING"}, "sub_state": {"@module":
+    "qtoolkit.io.pbs", "@class": "PBSState", "@version": "0.1.5.post38+g62b683f.d20241229",
+    "value": "R"}, "info": {"@module": "qtoolkit.core.data_objects", "@class": "QJobInfo",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "memory": null, "memory_per_cpu":
+    null, "nodes": 1, "cpus": 1, "threads_per_process": null, "time_limit": 3600},
+    "account": null, "runtime": 0, "queue_name": null}'
+- parse_job_kwargs: '{"exit_code": 0, "stdout": "", "stderr": ""}'
+  job_ref: 'null'

--- a/tests/test_data/io/pbs/parse_submit_output_inout.yaml
+++ b/tests/test_data/io/pbs/parse_submit_output_inout.yaml
@@ -1,0 +1,12 @@
+- parse_submit_kwargs: '{"exit_code": 1, "stdout": "", "stderr": "qsub: Unknown queue\n"}'
+  submission_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "SubmissionResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": null, "step_id": null,
+    "exit_code": 1, "stdout": "", "stderr": "qsub: Unknown queue\n", "status": {"@module":
+    "qtoolkit.core.data_objects", "@class": "SubmissionStatus", "@version": "0.1.5.post38+g62b683f.d20241229",
+    "value": "FAILED"}}'
+- parse_submit_kwargs: '{"exit_code": 0, "stdout": "24\n", "stderr": ""}'
+  submission_result_ref: '{"@module": "qtoolkit.core.data_objects", "@class": "SubmissionResult",
+    "@version": "0.1.5.post38+g62b683f.d20241229", "job_id": "24", "step_id": null,
+    "exit_code": 0, "stdout": "24\n", "stderr": "", "status": {"@module": "qtoolkit.core.data_objects",
+    "@class": "SubmissionStatus", "@version": "0.1.5.post38+g62b683f.d20241229", "value":
+    "SUCCESSFUL"}}'


### PR DESCRIPTION
To address this issue https://github.com/Matgenix/jobflow-remote/issues/112 introduce a sanitization for the name of the jobs for PBS and SGE. The choice of the characters to replace is based on explicit tests in the PBS and SGE containers from jobflow-remote's integration tests.

Also adding test for PBS as some regression was introduced when adding SGE. It would be better to add integration tests similar to jobflow-remote to improve the reliability.