### PR TITLE
Raise if qstat command fails in PBS

### DIFF
--- a/src/qtoolkit/io/pbs.py
+++ b/src/qtoolkit/io/pbs.py
@@ -4,7 +4,7 @@ import re
 from typing import ClassVar
 
 from qtoolkit.core.data_objects import QJob, QJobInfo, QState, QSubState
-from qtoolkit.core.exceptions import OutputParsingError
+from qtoolkit.core.exceptions import CommandFailedError, OutputParsingError
 from qtoolkit.io.pbs_base import PBSIOBase
 
 # States in PBS from qstat's man.
@@ -156,7 +156,14 @@ $${qverbatim}"""
         # qstat: Unknown Job Id 10000.c2cf5fbe1102
         # qstat: 1008.c2cf5fbe1102 Job has finished, use -x or -H to
         #   obtain historical job information
-        # TODO raise if these two kinds of error are not present and exit_code != 0?
+        # Error is raised only if they are present in stderr
+        if (
+            exit_code != 0
+            and "Unknown Job Id" not in stderr
+            and "Job has finished" not in stderr
+        ):
+            msg = f"command qstat failed: {stderr}"
+            raise CommandFailedError(msg)
 
         # Split by the beginning of "Job Id:" and iterate on the different chunks.
         # Matching the beginning of the line to avoid problems in case the "Job Id"


### PR DESCRIPTION
PBS returns an exit_code != 0 even if the execution of the qstat command is partially succeeded while getting the information for a list of jobs. For this reason we did not raise based on exit_code. With this PR the `parse_jobs_list_output` in `PBSIO` will start raising if exit_code is not 0 and selected messages are not present in stderr.

Hopefully this may help addressing https://github.com/Matgenix/jobflow-remote/issues/403