### PR TITLE
Option to run integration tests on selected containers

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = []
 dev = ["pre-commit>=3.0.0"]
 tests = [
     "monty>=2022.9.9",
-    "pytest-cov==4.0.0",
-    "pytest-mock==3.10.0",
-    "pytest==7.2.1",
+    "pytest-cov >= 6,< 8",
+    "pytest-mock ~= 3.14",
+    "pytest ~= 8.0",
     "ruamel.yaml",
     "python-on-whales ~=0.75",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Other/Nonlisted Topic",
     "Topic :: Scientific/Engineering",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,19 +68,19 @@ def check_io_requirements(request, io_types):
 
 
 @pytest.fixture(scope="session")
-def skip_if_not_slurm(io_types):
+def skip_if_no_slurm(io_types):
     if "slurm" not in io_types:
         pytest.skip("slurm container is required to run this test")
 
 
 @pytest.fixture(scope="session")
-def skip_if_not_pbs(io_types):
+def skip_if_no_pbs(io_types):
     if "pbs" not in io_types:
         pytest.skip("pbs container is required to run this test")
 
 
 @pytest.fixture(scope="session")
-def skip_if_not_sge(io_types):
+def skip_if_no_sge(io_types):
     if "sge" not in io_types:
         pytest.skip("sge container is required to run this test")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,81 @@ import pytest
 from python_on_whales import DockerClient
 from python_on_whales import docker as docker_pow
 
+IO_TYPES = [
+    "slurm",
+    "sge",
+    "pbs",
+]
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--io-types",
+        "--it",
+        dest="io_types",
+        nargs="+",
+        help="List of IO types to be used for the integration tests. All available if not specified.",
+        default=None,
+        action="store",
+        choices=IO_TYPES,
+    )
+
+
+@pytest.fixture(scope="session")
+def io_types(request):
+    """
+    List of worker types activated during the integration tests
+    """
+    it = request.config.getoption("--io-types")
+    if it is None:
+        it = list(IO_TYPES)
+    return it
+
+
+@pytest.fixture(autouse=True)
+def check_io_requirements(request, io_types):
+    """
+    Automatically check io requirements and skip if needed.
+
+    Will skip, depending on the selected io types:
+      * if there is a parametrization with a parameter named "get_host_kwargs" and
+        the value contains a "type" that does not belong to the selected IOs corresponding
+        parameter value will be skipped
+    """
+
+    # handle tests with
+    if (
+        hasattr(request.node, "callspec")
+        and "get_host_kwargs" in request.node.callspec.params
+    ):
+        host_kwargs = request.node.callspec.params["get_host_kwargs"]
+        if (
+            host_kwargs is not None
+            and isinstance(host_kwargs, dict)
+            and host_kwargs.get("type") not in io_types
+        ):
+            pytest.skip(
+                f"IO with kwargs '{host_kwargs}' not in selected workers {io_types}"
+            )
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_slurm(io_types):
+    if "slurm" not in io_types:
+        pytest.skip("slurm container is required to run this test")
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_pbs(io_types):
+    if "pbs" not in io_types:
+        pytest.skip("pbs container is required to run this test")
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_sge(io_types):
+    if "sge" not in io_types:
+        pytest.skip("sge container is required to run this test")
+
 
 def _get_free_port(upper_bound=90_000):
     """Returns a random free port, with an upper bound.
@@ -62,7 +137,11 @@ def slurm_host(slurm_ssh_port):
             host="localhost",
             port=slurm_ssh_port,
             user=username,
-            connect_kwargs={"password": username},
+            connect_kwargs={
+                "password": username,
+                "allow_agent": False,
+                "look_for_keys": False,
+            },
         )
         return RemoteHost(conf)
 
@@ -79,7 +158,11 @@ def sge_host(sge_ssh_port):
             host="localhost",
             port=sge_ssh_port,
             user=username,
-            connect_kwargs={"password": username},
+            connect_kwargs={
+                "password": username,
+                "allow_agent": False,
+                "look_for_keys": False,
+            },
         )
         return RemoteHost(conf)
 
@@ -96,7 +179,11 @@ def pbs_host(pbs_ssh_port):
             host="localhost",
             port=pbs_ssh_port,
             user=username,
-            connect_kwargs={"password": username},
+            connect_kwargs={
+                "password": username,
+                "allow_agent": False,
+                "look_for_keys": False,
+            },
         )
         return RemoteHost(conf)
 
@@ -119,10 +206,13 @@ def get_host(get_host_kwargs, slurm_host, pbs_host, sge_host):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def bake_containers():
+def bake_containers(io_types):
+    targets = io_types
+    if not targets:
+        return
     hcl_path = Path(__file__).parent.resolve() / "dockerfiles/docker-bake.hcl"
     docker_pow.buildx.bake(
-        targets=["slurm", "sge", "pbs"],
+        targets=targets,
         files=hcl_path,
         set={"*.context": str(Path(__file__).parent.parent.parent.resolve())},
     )
@@ -130,12 +220,15 @@ def bake_containers():
 
 @pytest.fixture(scope="session", autouse=True)
 def compose_containers(
-    slurm_ssh_port, sge_ssh_port, pbs_ssh_port, bake_containers, pytestconfig
+    slurm_ssh_port, sge_ssh_port, pbs_ssh_port, bake_containers, pytestconfig, io_types
 ):
-    compose_yaml = f"""
+    compose_yaml = """
 name: qtoolkit_testing
 services:
+"""
 
+    if "slurm" in io_types:
+        compose_yaml += f"""
   qtoolkit_testing_slurm:
     image: ghcr.io/matgenix/qtoolkit-testing-slurm:latest
     container_name: qtoolkit_slurm
@@ -149,7 +242,9 @@ services:
       timeout: 1s
       retries: 30
       start_period: 2s
-
+"""
+    if "sge" in io_types:
+        compose_yaml += f"""
   qtoolkit_testing_sge:
     image: ghcr.io/matgenix/qtoolkit-testing-sge:latest
     container_name: qtoolkit_sge
@@ -163,7 +258,10 @@ services:
       timeout: 1s
       retries: 30
       start_period: 2s
+"""
 
+    if "pbs" in io_types:
+        compose_yaml += f"""
   qtoolkit_testing_pbs:
     image: ghcr.io/matgenix/qtoolkit-testing-pbs:latest
     container_name: qtoolkit_pbs

--- a/tests/integration/host/test_remote.py
+++ b/tests/integration/host/test_remote.py
@@ -5,10 +5,13 @@ import re
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("CI"),
-    reason="Only run integration tests in CI, unless forced with 'CI' env var",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("CI"),
+        reason="Only run integration tests in CI, unless forced with 'CI' env var",
+    ),
+    pytest.mark.usefixtures("skip_if_not_slurm"),
+]
 
 
 def test_remote(slurm_host, mocker, compose_containers):

--- a/tests/integration/host/test_remote.py
+++ b/tests/integration/host/test_remote.py
@@ -10,7 +10,7 @@ pytestmark = [
         not os.environ.get("CI"),
         reason="Only run integration tests in CI, unless forced with 'CI' env var",
     ),
-    pytest.mark.usefixtures("skip_if_not_slurm"),
+    pytest.mark.usefixtures("skip_if_no_slurm"),
 ]
 
 

--- a/tests/integration/pbs/test_core.py
+++ b/tests/integration/pbs/test_core.py
@@ -9,7 +9,7 @@ pytestmark = [
         not os.environ.get("CI"),
         reason="Only run integration tests in CI, unless forced with 'CI' env var",
     ),
-    pytest.mark.usefixtures("skip_if_not_pbs"),
+    pytest.mark.usefixtures("skip_if_no_pbs"),
 ]
 
 

--- a/tests/integration/pbs/test_core.py
+++ b/tests/integration/pbs/test_core.py
@@ -1,0 +1,64 @@
+# ruff: noqa: SLF001
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("CI"),
+        reason="Only run integration tests in CI, unless forced with 'CI' env var",
+    ),
+    pytest.mark.usefixtures("skip_if_not_pbs"),
+]
+
+
+def test_errors(pbs_host):
+    from qtoolkit.core.exceptions import CommandFailedError, InvalidJobIDError
+    from qtoolkit.io.pbs import PBSIO
+    from qtoolkit.manager import QueueManager
+
+    pbs_io = PBSIO()
+    johndoe_host = pbs_host("johndoe")
+
+    qm = QueueManager(host=johndoe_host, scheduler_io=pbs_io)
+
+    stdout, stderr, returncode = qm.execute_cmd("qstat blabli")
+    assert "qstat: Unknown queue destination blabli" in stderr
+
+    stdout, stderr, returncode = qm.execute_cmd("qstat -b")
+    assert "qstat: invalid option -- 'b'" in stderr
+
+    with pytest.raises(
+        InvalidJobIDError, match=r"Job ID \'a wrong id\' is invalid for this scheduler"
+    ):
+        qm.get_jobs_list(["a wrong id"])
+
+    pbs_io.check_job_ids = False
+
+    with pytest.raises(CommandFailedError):
+        qm.get_jobs_list(["a wrong id"])
+
+    number = "9999999"
+    jobs_list = qm.get_jobs_list([number])
+    assert jobs_list == []
+
+    pbs_io.check_job_ids = True
+
+    sr = qm.submit("sleep 5", work_dir=johndoe_host.config.root_dir)
+    job_id = sr.job_id
+    suffix = job_id.split(".", 1)[1]
+
+    jobs_list = qm.get_jobs_list([job_id])
+    assert isinstance(jobs_list, list)
+    assert len(jobs_list) == 1
+    assert jobs_list[0].job_id == job_id
+
+    jobs_list = qm.get_jobs_list([f"9999999.{suffix}"])
+    assert jobs_list == []
+
+    import time
+
+    time.sleep(10)
+    jobs_list = qm.get_jobs_list([job_id])
+    assert jobs_list == []

--- a/tests/integration/sge/test_core.py
+++ b/tests/integration/sge/test_core.py
@@ -9,7 +9,7 @@ pytestmark = [
         not os.environ.get("CI"),
         reason="Only run integration tests in CI, unless forced with 'CI' env var",
     ),
-    pytest.mark.usefixtures("skip_if_not_sge"),
+    pytest.mark.usefixtures("skip_if_no_sge"),
 ]
 
 

--- a/tests/integration/sge/test_core.py
+++ b/tests/integration/sge/test_core.py
@@ -4,10 +4,13 @@ import os
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("CI"),
-    reason="Only run integration tests in CI, unless forced with 'CI' env var",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("CI"),
+        reason="Only run integration tests in CI, unless forced with 'CI' env var",
+    ),
+    pytest.mark.usefixtures("skip_if_not_sge"),
+]
 
 
 def test_errors(sge_host):

--- a/tests/integration/slurm/test_core.py
+++ b/tests/integration/slurm/test_core.py
@@ -4,10 +4,13 @@ import os
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("CI"),
-    reason="Only run integration tests in CI, unless forced with 'CI' env var",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("CI"),
+        reason="Only run integration tests in CI, unless forced with 'CI' env var",
+    ),
+    pytest.mark.usefixtures("skip_if_not_slurm"),
+]
 
 
 def test_errors(slurm_host):

--- a/tests/integration/slurm/test_core.py
+++ b/tests/integration/slurm/test_core.py
@@ -9,7 +9,7 @@ pytestmark = [
         not os.environ.get("CI"),
         reason="Only run integration tests in CI, unless forced with 'CI' env var",
     ),
-    pytest.mark.usefixtures("skip_if_not_slurm"),
+    pytest.mark.usefixtures("skip_if_no_slurm"),
 ]
 
 


### PR DESCRIPTION
As done previously in jobflow-remote, added a `--io-types` option to run the integration tests on a subset of the containers. 
Also added a few integration tests for PBS and testing for python 3.14.